### PR TITLE
fix: ルールページの得点表を修正

### DIFF
--- a/rule.html
+++ b/rule.html
@@ -177,23 +177,7 @@
               </tr>
               <tr>
                 <td>
-                  相手より先にゴール状態になった<br /><small
-                    >※ゴール状態とは水草エリアに戻ったのちに「フィニッシュ」と宣言したこと</small
-                  >
-                </td>
-                <td class="points">1</td>
-              </tr>
-              <tr>
-                <td>
                   スタートしたコース上のどじょうを水草エリアに持ち帰った<br /><small
-                    >※1個あたり<br />※最大3点まで</small
-                  >
-                </td>
-                <td class="points">1</td>
-              </tr>
-              <tr>
-                <td>
-                  [決勝戦のみ]激レアどじょうを水草エリアに持ち帰った<br /><small
                     >※1個あたり<br />※最大3点まで</small
                   >
                 </td>
@@ -206,6 +190,22 @@
                   >
                 </td>
                 <td class="points">5</td>
+              </tr>
+              <tr>
+                <td>
+                  [決勝戦のみ]相手より先にゴール状態になった<br /><small
+                    >※ゴール状態とは水草エリアに戻ったのちに「フィニッシュ」と宣言したこと</small
+                  >
+                </td>
+                <td class="points">1</td>
+              </tr>
+              <tr>
+                <td>
+                  [決勝戦のみ]激レアどじょうを水草エリアに持ち帰った<br /><small
+                    >※1個あたり<br />※最大3点まで</small
+                  >
+                </td>
+                <td class="points">1</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
・相手より先にゴール状態になったら1点のルールを決勝戦のみに修正
・得点の順番を入れ替え